### PR TITLE
Add gnome-menus dependency

### DIFF
--- a/x11-misc/plank/plank-0.11.89.ebuild
+++ b/x11-misc/plank/plank-0.11.89.ebuild
@@ -21,6 +21,7 @@ DEPEND="
 	$(vala_depend)
 	dev-util/intltool
 	gnome-base/gnome-common
+	gnome-base/gnome-menus
 	sys-devel/gettext
 	virtual/pkgconfig
 "


### PR DESCRIPTION
configure script fails without `gnome-base/gnome-menus` with:
```
checking for GNOMEMENU3... no
configure: error: Package requirements (libgnome-menu-3.0) were not met:

Package 'libgnome-menu-3.0', required by 'virtual:world', not found
```