### PR TITLE
Flowblade fix mlt python deps

### DIFF
--- a/media-video/flowblade/flowblade-2.4.0.1-r1.ebuild
+++ b/media-video/flowblade/flowblade-2.4.0.1-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_8 )
 
-inherit desktop python-any-r1 xdg
+inherit desktop python-single-r1 xdg
 
 DESCRIPTION="A multitrack non-linear video editor"
 HOMEPAGE="https://github.com/jliljebl/flowblade"
@@ -26,14 +26,14 @@ IUSE=""
 
 DEPEND="
 	${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
-	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk]
-	$(python_gen_any_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
 	>=x11-libs/gtk+-3.0:3[introspection]
+	$(python_gen_cond_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
+	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk,${PYTHON_SINGLE_USEDEP}]
+	$(python_gen_cond_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
 	media-plugins/frei0r-plugins
 	media-plugins/swh-plugins
-	$(python_gen_any_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
-	$(python_gen_any_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
+	$(python_gen_cond_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
+	$(python_gen_cond_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
 	gnome-base/librsvg:2=
 	media-gfx/gmic[ffmpeg,X]
 	dev-libs/glib:2[dbus]
@@ -44,7 +44,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
-	python-any-r1_pkg_setup
+	python-single-r1_pkg_setup
 }
 
 src_prepare() {

--- a/media-video/flowblade/flowblade-2.4.0.1-r1.ebuild
+++ b/media-video/flowblade/flowblade-2.4.0.1-r1.ebuild
@@ -26,19 +26,19 @@ IUSE=""
 
 DEPEND="
 	${PYTHON_DEPS}
-	>=x11-libs/gtk+-3.0:3
 	$(python_gen_any_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
 	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk]
 	$(python_gen_any_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
+	>=x11-libs/gtk+-3.0:3[introspection]
 	media-plugins/frei0r-plugins
 	media-plugins/swh-plugins
-	$(python_gen_any_dep 'dev-python/pycairo[${PYTHON_USEDEP}]')
 	$(python_gen_any_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
 	$(python_gen_any_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
 	gnome-base/librsvg:2=
 	media-gfx/gmic[ffmpeg,X]
 	dev-libs/glib:2[dbus]
-	x11-libs/gdk-pixbuf:2
+	x11-libs/pango[introspection]
+	x11-libs/gdk-pixbuf:2[introspection]
 	media-video/ffmpeg
 "
 RDEPEND="${DEPEND}"

--- a/media-video/flowblade/flowblade-2.6.3.ebuild
+++ b/media-video/flowblade/flowblade-2.6.3.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_8 )
 
-inherit desktop python-any-r1 xdg
+inherit desktop python-single-r1 xdg
 
 DESCRIPTION="A multitrack non-linear video editor"
 HOMEPAGE="https://github.com/jliljebl/flowblade"
@@ -26,14 +26,14 @@ IUSE=""
 
 DEPEND="
 	${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
-	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk]
-	$(python_gen_any_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
 	>=x11-libs/gtk+-3.0:3[introspection]
+	$(python_gen_cond_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
+	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk,${PYTHON_SINGLE_USEDEP}]
+	$(python_gen_cond_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
 	media-plugins/frei0r-plugins
 	media-plugins/swh-plugins
-	$(python_gen_any_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
-	$(python_gen_any_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
+	$(python_gen_cond_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
+	$(python_gen_cond_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
 	gnome-base/librsvg:2=
 	media-gfx/gmic[ffmpeg,X]
 	dev-libs/glib:2[dbus]
@@ -44,7 +44,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
-	python-any-r1_pkg_setup
+	python-single-r1_pkg_setup
 }
 
 src_prepare() {

--- a/media-video/flowblade/flowblade-2.6.3.ebuild
+++ b/media-video/flowblade/flowblade-2.6.3.ebuild
@@ -26,19 +26,19 @@ IUSE=""
 
 DEPEND="
 	${PYTHON_DEPS}
-	>=x11-libs/gtk+-3.0:3
 	$(python_gen_any_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
 	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk]
 	$(python_gen_any_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
+	>=x11-libs/gtk+-3.0:3[introspection]
 	media-plugins/frei0r-plugins
 	media-plugins/swh-plugins
-	$(python_gen_any_dep 'dev-python/pycairo[${PYTHON_USEDEP}]')
 	$(python_gen_any_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
 	$(python_gen_any_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
 	gnome-base/librsvg:2=
 	media-gfx/gmic[ffmpeg,X]
 	dev-libs/glib:2[dbus]
-	x11-libs/gdk-pixbuf:2
+	x11-libs/pango[introspection]
+	x11-libs/gdk-pixbuf:2[introspection]
 	media-video/ffmpeg
 "
 RDEPEND="${DEPEND}"

--- a/media-video/flowblade/flowblade-9999-r1.ebuild
+++ b/media-video/flowblade/flowblade-9999-r1.ebuild
@@ -26,19 +26,19 @@ IUSE=""
 
 DEPEND="
 	${PYTHON_DEPS}
-	>=x11-libs/gtk+-3.0:3
 	$(python_gen_any_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
 	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk]
 	$(python_gen_any_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
+	>=x11-libs/gtk+-3.0:3[introspection]
 	media-plugins/frei0r-plugins
 	media-plugins/swh-plugins
-	$(python_gen_any_dep 'dev-python/pycairo[${PYTHON_USEDEP}]' )
 	$(python_gen_any_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
 	$(python_gen_any_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
 	gnome-base/librsvg:2=
 	media-gfx/gmic[ffmpeg,X]
 	dev-libs/glib:2[dbus]
-	x11-libs/gdk-pixbuf:2
+	x11-libs/pango[introspection]
+	x11-libs/gdk-pixbuf:2[introspection]
 	media-video/ffmpeg
 "
 RDEPEND="${DEPEND}"

--- a/media-video/flowblade/flowblade-9999-r1.ebuild
+++ b/media-video/flowblade/flowblade-9999-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_8 )
 
-inherit desktop python-any-r1 xdg
+inherit desktop python-single-r1 xdg
 
 DESCRIPTION="A multitrack non-linear video editor"
 HOMEPAGE="https://github.com/jliljebl/flowblade"
@@ -26,14 +26,14 @@ IUSE=""
 
 DEPEND="
 	${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
-	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk]
-	$(python_gen_any_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
 	>=x11-libs/gtk+-3.0:3[introspection]
+	$(python_gen_cond_dep 'dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]' )
+	>=media-libs/mlt-6.18.0[python,ffmpeg,gtk,${PYTHON_SINGLE_USEDEP}]
+	$(python_gen_cond_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]' )
 	media-plugins/frei0r-plugins
 	media-plugins/swh-plugins
-	$(python_gen_any_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
-	$(python_gen_any_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
+	$(python_gen_cond_dep 'dev-python/numpy[${PYTHON_USEDEP}]' )
+	$(python_gen_cond_dep 'dev-python/pillow:0[${PYTHON_USEDEP}]' )
 	gnome-base/librsvg:2=
 	media-gfx/gmic[ffmpeg,X]
 	dev-libs/glib:2[dbus]
@@ -44,7 +44,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
-	python-any-r1_pkg_setup
+	python-single-r1_pkg_setup
 }
 
 src_prepare() {

--- a/media-video/flowblade/flowblade-9999-r1.ebuild
+++ b/media-video/flowblade/flowblade-9999-r1.ebuild
@@ -48,7 +48,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	eapply -p2 "${FILESDIR}/${PN}-2.4-install-dir-fix.patch"
+	eapply -p2 "${FILESDIR}/${PN}-2.6-install-dir-fix.patch"
 	default
 }
 


### PR DESCRIPTION
Current ebuild specify mlt version without any PYTHON_DEPS. It may be lack if mlt built with same python targets as flowblade, but for me single target for now is python3_7. Unfortunally python-any has no support for single-target packages. Its PYTHON_USEDEP explicitly writes python_target_pythonP_V and -python-single-target-pythonP_V for compatible python:P.V. But mlt is single-target package, so flowblade also needs to be same.

Some deps where not up to date, some must have [introspection], while did not.